### PR TITLE
FOLIOSYNC-7 Add method to retrieve SRS MARC

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ client.find_instance_record(instance_record_id: 'some-instance-record-id')
 client.find_instance_record(instance_record_hrid: 'some-instance-record-hrid')
 client.find_source_record(instance_record_id: 'some-instance-record-id')
 client.find_source_record(instance_record_hrid: 'some-instance-record-hrid')
+client.find_source_marc_records(modified_since: '2025-01-01T00:00:00Z') { |marc_record_hash| }
+client.find_source_marc_records(with_965_value: '965abc') { |marc_record_hash| }
+client.find_source_marc_records(modified_since: '2025-01-01T00:00:00Z', with_965_value: '965abc') { |marc_record_hash| }
 
 # Convert a FOLIO MARC source record to a marc gem MARC::Record object:
 source_record = client.find_source_record(instance_record_id: 'some-instance-record-id')


### PR DESCRIPTION
# Part of [FOLIOSYNC-7](https://columbiauniversitylibraries.atlassian.net/browse/FOLIOSYNC-7)

Adds `find_source_marc_records` method to retrieve SRS MARC records based on their modification time. When the modification time is not supplied, it retrieves all MARC records. The method handles pagination and yields to a block.